### PR TITLE
Fix npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "files": [
     "index.js",
-    "bootprint-cli.js"
+    "bin/bootprint.js"
   ],
   "devDependencies": {
     "bootprint-swagger": "^0.13.1",


### PR DESCRIPTION
Hi there,

First of all, thanks for your work on this module, I find it quite useful.

Currently "npm install" fails with a ENONENT error, can't find bin/bootprint.js.

This seems to be a consequence of bootprint-cli.js having been renamed to bin/bootprint.js in 78ce862.

Please consider this pull request to fix it.

Thanks again !